### PR TITLE
[Feature] 장바구니 상품 구매 구현

### DIFF
--- a/src/app/cart/CartPage.tsx
+++ b/src/app/cart/CartPage.tsx
@@ -128,20 +128,25 @@ export default function CartPage({ cartData }: CartPageProps) {
         <>
           <div className="flex flex-col">
             <div className="h-[400px] overflow-y-auto hide-scrollbar">
-              {cartData.length !== 0 &&
-                cartData.map((item, index: number) => (
-                  <CartCard
-                    key={index}
-                    name={item.product.name}
-                    brewery={item.product.extra.brewery}
-                    price={item.product.price}
-                    alcohol={item.product.extra.taste.alcohol}
-                    quantity={item.quantity}
-                    image={item.product.image.path}
-                    handleQuantityChange={handleQuantityChange} // 수량 변경 시 핸들러 호출
-                    _id={item._id}
-                  />
-                ))}
+              {Array.from(new Set(cartData.map((item) => item._id))).map((id) => {
+                const item = cartData.find((cartItem) => cartItem._id === id);
+                if (item) {
+                  return (
+                    <CartCard
+                      key={id}
+                      name={item.product.name}
+                      brewery={item.product.extra.brewery}
+                      price={item.product.price}
+                      alcohol={item.product.extra.taste.alcohol}
+                      quantity={item.quantity}
+                      image={item.product.image.path}
+                      handleQuantityChange={handleQuantityChange}
+                      _id={item._id}
+                    />
+                  );
+                }
+                return null;
+              })}
             </div>
             <div className="mt-12">
               <div className="flex content justify-between mb-[28px]">

--- a/src/app/cart/CartPage.tsx
+++ b/src/app/cart/CartPage.tsx
@@ -15,6 +15,7 @@ export interface CartPageProps {
   cartData: {
     _id: number;
     product: {
+      _id: number;
       name: string;
       extra: {
         brewery: string;
@@ -63,7 +64,7 @@ export default function CartPage({ cartData, total }: CartPageProps) {
         console.error("Error fetching cost data:", error);
       }
     }
-  }, [token, cartItems]);
+  }, [token]);
 
   // url의 request값을 받아와 변수에 저장
   const request = useSearchParams().get("request");
@@ -94,7 +95,7 @@ export default function CartPage({ cartData, total }: CartPageProps) {
 
   useEffect(() => {
     fetchCartData();
-  }, [fetchCartData, total]);
+  }, [fetchCartData]);
 
   const handleQuantityChange = () => {
     fetchCartData();
@@ -106,7 +107,7 @@ export default function CartPage({ cartData, total }: CartPageProps) {
     const userInfo = await getUserInfo(session.data?.user?.id!);
     if (userInfo.item.extra.isAdult) {
       // 로그인이 되어있고 성인인증도 돼있을 때
-      router.push("/pay");
+      router.push("/cart/pay");
     } else {
       // 로그인은 되어있지만 성인인증이 되지 않았을 때
       // url의 request값이 true면 모달 띄우기(stateless modal)

--- a/src/app/cart/CartPage.tsx
+++ b/src/app/cart/CartPage.tsx
@@ -63,7 +63,7 @@ export default function CartPage({ cartData, total }: CartPageProps) {
         console.error("Error fetching cost data:", error);
       }
     }
-  }, [token]);
+  }, [token, cartItems]);
 
   // url의 request값을 받아와 변수에 저장
   const request = useSearchParams().get("request");

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,10 +1,7 @@
-"use client";
-import { useSession } from "next-auth/react";
 import CartPage from "./CartPage";
-import { useState, useEffect } from "react";
-import { useCartProductStore } from "@/zustand/Store";
+import { auth } from "@/auth";
 
-async function fetchCart(token: string | null) {
+export async function fetchGetCart(token: string | undefined) {
   const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
   const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
   const url = `${API_SERVER}/carts`;
@@ -16,34 +13,14 @@ async function fetchCart(token: string | null) {
   });
   const resJson = await res.json();
   if (!resJson.ok) {
-    throw new Error("error");
+    console.error(Error);
   }
-  return resJson.item;
+  return resJson;
 }
-export default function Page() {
-  const session = useSession();
-  // const [cartData, setCartData] = useState([]);
-  const { cartData, addToCart } = useCartProductStore((state) => ({
-    cartData: state.cartData,
-    addToCart: state.addToCart,
-  }));
-  useEffect(() => {
-    const token = session?.data?.accessToken;
-    const getCartData = async () => {
-      if (token) {
-        const data = await fetchCart(token);
-        console.log(data);
-        data.map((v) => {
-          if (addToCart) {
-            // addToCart가 정의되어 있는지 확인
-            addToCart(v);
-          }
-        });
-      }
-    };
-    getCartData();
-  }, [session.data]);
-  console.log(cartData);
+export default async function Page() {
+  const session = await auth();
 
-  return <CartPage cartData={cartData} />;
+  const cartData = await fetchGetCart(session?.accessToken);
+
+  return <CartPage cartData={cartData.item} total={cartData.cost} />;
 }

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -19,7 +19,6 @@ export async function fetchGetCart(token: string | undefined) {
 }
 export default async function Page() {
   const session = await auth();
-
   const cartData = await fetchGetCart(session?.accessToken);
 
   return <CartPage cartData={cartData.item} total={cartData.cost} />;

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -2,6 +2,7 @@
 import { useSession } from "next-auth/react";
 import CartPage from "./CartPage";
 import { useState, useEffect } from "react";
+import { useCartProductStore } from "@/zustand/Store";
 
 async function fetchCart(token: string | null) {
   const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
@@ -21,18 +22,28 @@ async function fetchCart(token: string | null) {
 }
 export default function Page() {
   const session = useSession();
-  const [cartData, setCartData] = useState([]);
-
+  // const [cartData, setCartData] = useState([]);
+  const { cartData, addToCart } = useCartProductStore((state) => ({
+    cartData: state.cartData,
+    addToCart: state.addToCart,
+  }));
   useEffect(() => {
     const token = session?.data?.accessToken;
     const getCartData = async () => {
       if (token) {
         const data = await fetchCart(token);
-        setCartData(data);
+        console.log(data);
+        data.map((v) => {
+          if (addToCart) {
+            // addToCart가 정의되어 있는지 확인
+            addToCart(v);
+          }
+        });
       }
     };
     getCartData();
   }, [session.data]);
+  console.log(cartData);
 
   return <CartPage cartData={cartData} />;
 }

--- a/src/app/cart/pay/Address.tsx
+++ b/src/app/cart/pay/Address.tsx
@@ -1,0 +1,96 @@
+import Button from "@/components/Button";
+import Script from "next/script";
+import { useEffect, useState } from "react";
+
+declare global {
+  interface Window {
+    daum: any;
+  }
+}
+
+interface Address {
+  address: string;
+  zonecode: string;
+}
+
+export default function Address({
+  setAddressFilled,
+}: {
+  setAddressFilled: (filled: boolean) => void;
+}) {
+  const [addrDetail, setAddrDetail] = useState<string>("");
+  const [isScriptLoaded, setIsScriptLoaded] = useState<boolean>(false);
+
+  const onClickAddr = () => {
+    if (isScriptLoaded && window.daum?.Postcode) {
+      new window.daum.Postcode({
+        oncomplete: function (data: Address) {
+          const addrInput = document.getElementById("addr") as HTMLInputElement;
+          const zipNoInput = document.getElementById("zipNo") as HTMLInputElement;
+
+          addrInput.value = data.address;
+          zipNoInput.value = data.zonecode;
+          document.getElementById("addrDetail")?.focus();
+
+          setAddressFilled(!!addrDetail);
+        },
+      }).open();
+    } else {
+      console.error("Daum Postcode script is not loaded yet.");
+    }
+  };
+
+  const handleAddrDetailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setAddrDetail(value);
+    setAddressFilled(!!value);
+  };
+
+  useEffect(() => {
+    setAddressFilled(false); // 컴포넌트가 마운트될 때 주소 입력 상태 초기화
+  }, [setAddressFilled]);
+
+  return (
+    <div>
+      <span className="contentMedium">주소(필수)</span>
+      <div className="flex justify-between mt-5">
+        <Script
+          src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"
+          onLoad={() => setIsScriptLoaded(true)}
+        />
+
+        <div className="w-full mr-5">
+          <div className="flex flex-col gap-4 content">
+            <input
+              id="zipNo"
+              type="text"
+              placeholder="우편번호"
+              readOnly
+              onClick={onClickAddr}
+              className="border-b-[1px] border-lightGray py-2 focus:outline-none focus:border-primary"
+            />
+            <input
+              id="addr"
+              type="text"
+              placeholder="주소"
+              readOnly
+              onClick={onClickAddr}
+              className="border-b-[1px] border-lightGray py-2 focus:outline-none focus:border-primary"
+            />
+            <input
+              id="addrDetail"
+              type="text"
+              placeholder="상세주소"
+              value={addrDetail}
+              onChange={handleAddrDetailChange}
+              className="border-b-[1px] border-lightGray py-2 focus:outline-none focus:border-primary"
+            />
+          </div>
+        </div>
+        <Button onClick={onClickAddr} className="w-20 h-12">
+          검색
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cart/pay/OrderCard.tsx
+++ b/src/app/cart/pay/OrderCard.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Image from "next/image";
+
+import plus from "@/../public/images/icons/plus.svg";
+import minus from "@/../public/images/icons/minus.svg";
+import { InfoToast } from "@/toast/InfoToast";
+
+export interface CartCardProps {
+  name?: string;
+  brewery?: string;
+  price: number;
+  alcohol?: string;
+  quantity: number;
+  image: string;
+  setQuantity: (quantity: number) => void;
+  extra?: { brewery: string; taste?: { alcohol: string }[] }[];
+}
+
+export default function OrderCard({
+  name,
+  brewery,
+  price,
+  alcohol,
+  quantity,
+  image,
+  setQuantity,
+}: CartCardProps) {
+  const [count, setCount] = useState(quantity);
+
+  useEffect(() => {
+    setCount(quantity);
+  }, [quantity]);
+
+  useEffect(() => {
+    if (count !== quantity) {
+      setQuantity(count);
+    }
+  }, [count]);
+
+  const add = () => {
+    if (count >= 99) {
+      alert("상품은 100개 이상 구입할 수 없습니다.");
+    } else {
+      setCount((prev) => prev + 1);
+    }
+  };
+
+  const remove = () => {
+    if (count <= 1) {
+      InfoToast("1개 이하로는 주문할 수 없습니다.");
+    } else {
+      setCount((prev) => prev - 1);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between p-[10px] border-lightGray rounded-[10px] border-[1px] mb-5">
+      <Image
+        src={`https://api.fesp.shop${image}`}
+        alt="장바구니 아이템"
+        width={76}
+        height={76}
+        className="rounded-[8px] w-[76px] h-[76px] object-cover mr-3"
+      />
+      <div className="flex flex-col justify-center grow w-auto">
+        <span className="contentMedium text-ellipsis line-clamp-1">{name}</span>
+        <span className="text-gray text-[12px] mt-[4px] text-ellipsis line-clamp-1">{brewery}</span>
+        <div className="text-[10px] text-primary border-primary mt-[2px] border-[1px] w-[40px] h-[20px] p-1 flex items-center justify-center rounded-xl">
+          {alcohol}도
+        </div>
+      </div>
+      <div className="flex flex-col items-center justify-between py-2 ml-2 w-auto">
+        <div className="flex flex-row items-center w-[85px] justify-between">
+          <Image src={minus} alt="마이너스 아이콘" onClick={remove} />
+          <span className="contentMedium">{count}</span>
+          <Image src={plus} alt="플러스 아이콘" onClick={add} />
+        </div>
+        <span className="contentMedium">{(count * price).toLocaleString()}원</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cart/pay/PayPage.tsx
+++ b/src/app/cart/pay/PayPage.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import PortOne from "@portone/browser-sdk/v2";
+import Address from "./Address";
+import { useEffect, useState, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { errorToast } from "@/toast/errorToast";
+import Button from "@/components/Button";
+import ProgressBar from "./ProgressBar";
+import PaymentCompleted from "./complete/page";
+import { InfoToast } from "@/toast/InfoToast";
+import OrderCard from "./OrderCard";
+import { CartPageProps } from "../CartPage";
+
+const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
+const DOMAIN = process.env.NEXT_PUBLIC_API_NEXT_SERVER;
+const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
+const STORE_ID = process.env.NEXT_PUBLIC_TOSS_CLIENT_STORE_ID ?? "";
+const CHANNEL_KEY = process.env.NEXT_PUBLIC_TOSS_CHANNEL_KEY;
+
+export default function PayPage({ cartData, total }: CartPageProps) {
+  const [currentPage, setCurrentPage] = useState<number>(0);
+  const [addressFilled, setAddressFilled] = useState<boolean>(false);
+  const [isMounted, setIsMounted] = useState<boolean>(false);
+  const [shippingFees, setShippingFees] = useState<number>(0);
+  const [updatedCartData, setUpdatedCartData] = useState(cartData);
+  const [totalPrice, setTotalPrice] = useState<number>(0);
+  const { data: session } = useSession();
+  const token = session?.accessToken;
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    const newTotalPrice = updatedCartData.reduce(
+      (sum, item) => sum + item.product.price * item.quantity,
+      0,
+    );
+    setTotalPrice(newTotalPrice);
+
+    if (newTotalPrice < 30000) {
+      setShippingFees(3000);
+    } else {
+      setShippingFees(0);
+    }
+  }, [updatedCartData]);
+
+  const fetchOrder = async () => {
+    try {
+      const response = await fetch(`${API_SERVER}/orders`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+          "client-id": `${CLIENT_ID}`,
+        },
+        body: JSON.stringify({
+          products: updatedCartData.map((v) => ({
+            _id: v.product._id,
+            quantity: v.quantity,
+          })),
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("주문 정보 전송에 실패했습니다.");
+      }
+    } catch (error: any) {
+      errorToast(error.message);
+    }
+  };
+  async function fetchCleanUpCart() {
+    try {
+      const response = await fetch(`${API_SERVER}/carts/cleanup`, {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session?.accessToken}`,
+          "client-id": `${CLIENT_ID}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("장바구니 비우기를 실패하였습니다.");
+      }
+    } catch (error: any) {
+      console.error("오류 발생:", error.message);
+    }
+  }
+  const handlePayment = async () => {
+    try {
+      const response = await PortOne.requestPayment({
+        storeId: STORE_ID,
+        paymentId: `payment-${crypto.randomUUID()}`,
+        orderName: "장바구니 구매",
+        totalAmount: totalPrice + shippingFees,
+        currency: "CURRENCY_KRW",
+        channelKey: CHANNEL_KEY,
+        payMethod: "CARD",
+        redirectUrl: `${DOMAIN}/cart/pay/payments?productId=${updatedCartData.map((item) => item.product._id).join("&productId=")}&quantity=${updatedCartData.map((item) => item.quantity).join("&quantity=")}`,
+      });
+
+      if (response?.code === "FAILURE_TYPE_PG") {
+        errorToast("결제 실패: " + response?.message);
+      } else {
+        if (token) {
+          await fetchOrder();
+          await fetchCleanUpCart();
+          setCurrentPage(1);
+        } else {
+          console.error("토큰이 없습니다.");
+        }
+      }
+    } catch (error: any) {
+      errorToast("결제 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleQuantityChange = useCallback(
+    (productId: number, newQuantity: number) => {
+      setUpdatedCartData((prevCartData) =>
+        prevCartData.map((item) =>
+          item._id === productId ? { ...item, quantity: newQuantity } : item,
+        ),
+      );
+    },
+    [updatedCartData],
+  );
+
+  if (!isMounted) {
+    return null;
+  }
+
+  return (
+    <div className="h-screen">
+      <ProgressBar currentPage={currentPage} />
+      {currentPage === 0 ? (
+        <main className="text-black">
+          <h2 className="mt-10 contentMedium">개인 정보</h2>
+          <div className="flex flex-col gap-3 mt-5">
+            <div className="flex justify-between content">
+              <p className="text-darkGray">이름</p>
+              <p>{session?.user?.name}</p>
+            </div>
+            <div className="flex justify-between content">
+              <p className="text-darkGray">전화번호</p>
+              <p>+82 10 1234 5678</p>
+            </div>
+            <div className="mt-10">
+              <Address setAddressFilled={setAddressFilled} />
+            </div>
+          </div>
+          <div className="flex flex-col gap-5 mt-10">
+            <h2 className="contentMedium">담은 술</h2>
+            {updatedCartData.map((v) => (
+              <OrderCard
+                key={v._id}
+                name={v.product.name}
+                brewery={v.product.extra.brewery}
+                price={v.product.price}
+                alcohol={v.product.extra.taste.alcohol}
+                quantity={v.quantity}
+                image={v.product.image.path}
+                setQuantity={(quantity) => handleQuantityChange(v._id, quantity)}
+              />
+            ))}
+          </div>
+          <h2 className="mt-5 contentMedium">결제 정보</h2>
+          <div className="flex flex-col gap-3 mt-5">
+            <div className="flex justify-between content">
+              <p className="text-darkGray">상품금액</p>
+              <p>{totalPrice.toLocaleString()}원</p>
+            </div>
+            <div className="flex justify-between content">
+              <p className="text-darkGray">배송비</p>
+              <p>{shippingFees.toLocaleString()}원</p>
+            </div>
+            <div className="flex justify-between content">
+              <p className="text-darkGray">결제방법</p>
+              <p>토스페이</p>
+            </div>
+            <div className="flex justify-between content">
+              <p className="text-darkGray">결제금액</p>
+              <p className="text-primary">{(totalPrice + shippingFees).toLocaleString()}원</p>
+            </div>
+          </div>
+          {addressFilled ? (
+            <Button onClick={handlePayment} className={`w-full py-5 mt-12 mb-9 contentMedium`}>
+              {`${(totalPrice + shippingFees).toLocaleString()}원 결제`}
+            </Button>
+          ) : (
+            <Button
+              onClick={() => InfoToast("주소를 입력해 주세요.")}
+              className={`w-full py-5 mt-12 mb-9 contentMedium cursor-not-allowed`}
+              color="disabled"
+            >
+              {`${(totalPrice + shippingFees).toLocaleString()}원 결제`}
+            </Button>
+          )}
+        </main>
+      ) : (
+        <PaymentCompleted />
+      )}
+    </div>
+  );
+}

--- a/src/app/cart/pay/ProgressBar.tsx
+++ b/src/app/cart/pay/ProgressBar.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+interface ProgressBarProps {
+  currentPage: number;
+}
+
+export default function ProgressBar({ currentPage }: ProgressBarProps) {
+  const [progress, setProgress] = useState<number>(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setProgress(currentPage === 0 ? 50 : 100);
+    }, 200);
+
+    return () => clearTimeout(timer);
+  }, [currentPage]);
+
+  return (
+    <div className="fixed top-14 h-[6px] w-full bg-whiteGray">
+      <div
+        className={`h-full bg-primary transition-all duration-700 ease-in-out`}
+        style={{ width: `${progress}%` }}
+      ></div>
+    </div>
+  );
+}

--- a/src/app/cart/pay/complete/page.tsx
+++ b/src/app/cart/pay/complete/page.tsx
@@ -1,0 +1,29 @@
+import { useSession } from "next-auth/react";
+import Image from "next/image";
+import Link from "next/link";
+
+import Button from "@/components/Button";
+import WelcomeGif from "@/../public/images/welcome.gif";
+
+export default function Page() {
+  // const { data: session } = useSession();
+
+  return (
+    <main className="flex flex-col items-center justify-between h-full text-center text-black titleMedium">
+      <div className="mt-20 ">
+        {/* <p>{session?.user?.name}님,</p> */}
+        <p className="text-primary">술상이 준비되었습니다!</p>
+        <p className="">빠른 시일 내에 배송해드릴게요!!</p>
+      </div>
+      <Image
+        src={WelcomeGif}
+        alt="주문 성공 시 나오는 술잔이 부딪히는 애니메이션"
+        width={428}
+        height={428}
+      />
+      <Link href={"/"} className="w-full">
+        <Button className="w-full py-5 mb-12 contentMedium">{"확인"}</Button>
+      </Link>
+    </main>
+  );
+}

--- a/src/app/cart/pay/page.tsx
+++ b/src/app/cart/pay/page.tsx
@@ -1,0 +1,10 @@
+import { auth } from "@/auth";
+import { fetchGetCart } from "../page";
+import PayPage from "./PayPage";
+
+export default async function page() {
+  const session = await auth();
+  const cartData = await fetchGetCart(session?.accessToken);
+
+  return <PayPage cartData={cartData.item} total={cartData.cost} />;
+}

--- a/src/app/cart/pay/payments/route.ts
+++ b/src/app/cart/pay/payments/route.ts
@@ -1,0 +1,106 @@
+import { auth } from "@/auth";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const paymentId = searchParams.get("paymentId");
+  const transactionType = searchParams.get("transactionType");
+  const txId = searchParams.get("txId");
+  const session = await auth();
+  const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
+  const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
+  const DOMAIN = process.env.NEXT_PUBLIC_API_NEXT_SERVER;
+
+  const productIds = searchParams.getAll("productId").map((id) => Number(id));
+  const quantities = searchParams.getAll("quantity").map((q) => Number(q));
+  const products = productIds.map((id, index) => ({
+    _id: id,
+    quantity: quantities[index] || 1,
+  }));
+
+  const code = searchParams.get("code");
+
+  try {
+    const PORTONE_API_SECRET = process.env.PORTONE_V2_SECRET;
+
+    const paymentResponse = await fetch(`https://api.portone.io/payments/${paymentId}`, {
+      method: "GET",
+      headers: { Authorization: `PortOne ${PORTONE_API_SECRET}` },
+    });
+
+    if (!paymentResponse.ok) throw new Error(`paymentResponse: ${await paymentResponse.json()}`);
+
+    const payment = await paymentResponse.json();
+    console.log("Payment Status:", payment.status);
+
+    if (code === "FAILURE_TYPE_PG") {
+      return new Response("Payment failed: 결제를 취소하였습니다.", {
+        status: 302,
+        headers: {
+          Location: `${DOMAIN}/detail/${productIds[0]}`,
+        },
+      });
+    }
+
+    if (payment.status === "FAILED") {
+      return new Response("Payment failed: 결제 실패", { status: 400 });
+    } else if (payment.status === "PAID") {
+      await fetchOrder();
+      await fetchCleanUpCart();
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: `${DOMAIN}/pay/complete`,
+        },
+      });
+    } else {
+      return new Response(null, {
+        status: 400,
+        headers: {
+          Location: `${DOMAIN}/detail/${productIds[0]}`,
+        },
+      });
+    }
+  } catch (error) {
+    console.error("Error:", error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+
+  async function fetchOrder() {
+    try {
+      const response = await fetch(`${API_SERVER}/orders`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session?.accessToken}`,
+          "client-id": `${CLIENT_ID}`,
+        },
+        body: JSON.stringify({ products }),
+      });
+
+      if (!response.ok) {
+        console.error(JSON.stringify(response.json()));
+        throw new Error("주문 정보 전송에 실패했습니다.");
+      }
+    } catch (error: any) {
+      console.error("오류 발생:", error.message);
+    }
+  }
+  async function fetchCleanUpCart() {
+    try {
+      const response = await fetch(`${API_SERVER}/carts/cleanup`, {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session?.accessToken}`,
+          "client-id": `${CLIENT_ID}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("장바구니 비우기를 실패하였습니다.");
+      }
+    } catch (error: any) {
+      console.error("오류 발생:", error.message);
+    }
+  }
+}

--- a/src/app/detail/[id]/ReplyForm.tsx
+++ b/src/app/detail/[id]/ReplyForm.tsx
@@ -120,7 +120,7 @@ export default function ReplyForm() {
     });
   });
 
-  const result = orderId.find((number) => number === id);
+  const result = orderId.find((v) => v.toString() === id);
 
   return (
     <>

--- a/src/components/CartCard.tsx
+++ b/src/components/CartCard.tsx
@@ -96,8 +96,6 @@ export default function CartCard({
         setQuantity(newQuantity);
       } else {
         const updatedItem = await fetchChangeCart(_id, newQuantity, token);
-        const refetchCart = await fetchGetCart(token);
-        console.log(refetchCart);
         setQuantity(updatedItem.quantity);
         handleQuantityChange(updatedItem.quantity);
       }

--- a/src/components/CartCard.tsx
+++ b/src/components/CartCard.tsx
@@ -8,6 +8,7 @@ import itemdelete from "../../public/images/icons/icon-trash.svg";
 
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import { fetchGetCart } from "@/app/cart/page";
 
 export interface CartCardProps {
   name?: string;
@@ -94,9 +95,11 @@ export default function CartCard({
         handleQuantityChange(newQuantity);
         setQuantity(newQuantity);
       } else {
-        await fetchChangeCart(_id, newQuantity, token);
-        setQuantity(newQuantity);
-        handleQuantityChange(newQuantity);
+        const updatedItem = await fetchChangeCart(_id, newQuantity, token);
+        const refetchCart = await fetchGetCart(token);
+        console.log(refetchCart);
+        setQuantity(updatedItem.quantity);
+        handleQuantityChange(updatedItem.quantity);
       }
     } catch (error) {
       alert("수량을 변경하는 중 오류가 발생했습니다.");

--- a/src/zustand/Store.ts
+++ b/src/zustand/Store.ts
@@ -1,23 +1,29 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
-interface ProductStore {
-  showDetail: boolean;
-  setShowDetail: (showDetail: boolean) => void;
+export interface ProductStore {
+  showDetail?: boolean;
+  setShowDetail?: (showDetail: boolean) => void;
   _id: number;
-  setId: (_id: number) => void;
+  setId?: (_id: number) => void;
   name: string;
-  setName: (name: string) => void;
+  setName?: (name: string) => void;
   price: number;
-  setPrice: (price: number) => void;
+  setPrice?: (price: number) => void;
   image: string;
-  setImage: (image: string) => void;
+  setImage?: (image: string) => void;
   quantity: number;
   setQuantity: (quantity: number) => void;
   brewery: string;
-  setBrewery: (brewery: string) => void;
+  setBrewery?: (brewery: string) => void;
   alcohol: string;
-  setAlcohol: (alcohol: string) => void;
+  setAlcohol?: (alcohol: string) => void;
+}
+
+interface CartProductStore {
+  cartData: ProductStore[];
+  addToCart?: (item: ProductStore) => void;
+  updateCartItem: (itemId: number, newQuantity: number) => void;
 }
 export const useProductStore = create<ProductStore>()(
   persist(
@@ -51,6 +57,40 @@ export const useProductStore = create<ProductStore>()(
         quantity: state.quantity,
         brewery: state.brewery,
         alcohol: state.alcohol,
+      }),
+    },
+  ),
+);
+export const useCartProductStore = create<CartProductStore>()(
+  persist(
+    (set) => ({
+      cartData: [],
+      addToCart: (item) =>
+        set((state) => {
+          const existingItem = state.cartData.find((cartItem) => cartItem._id === item._id);
+          if (existingItem) {
+            return state;
+          }
+          return {
+            cartData: [...state.cartData, item],
+          };
+        }),
+      updateCartItem: (itemId, newQuantity) =>
+        set((state) => {
+          const updatedCartData = state.cartData.map((cartItem) => {
+            if (cartItem._id === itemId) {
+              return { ...cartItem, quantity: newQuantity };
+            }
+            return cartItem;
+          });
+          return { cartData: updatedCartData };
+        }),
+    }),
+    {
+      name: "cart-product-storage",
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({
+        cartData: state.cartData,
       }),
     },
   ),


### PR DESCRIPTION
단일 상품 구매와 다른 페이지(/cart/pay)를 통해 구현했습니다.
장바구니의 상품의 구매에 성공하면 fetchCleanupCart 를 통해 장바구니를 비우게 하였습니다.

추가로 구매한 상품의 후기 작성 폼이 보이지 않던 오류를 해결했습니다.
구매한 상품의 아이디 타입과 현재 보고 있는 상품의 아이디 타입을 비교하여 후기 작성 폼이 보이도록 구현했는데 둘의 타입이 달라서 생긴 오류였습니다.

장바구니에 상품을 담고 장바구니로 이동하면 상품이 바로 보이지 않고 새로고침해야 보이는 오류가 있어 tanstackQuery를 통해 오류를 해결하겠습니다.
