### PR TITLE
[Fix]검색 오류 수정

### DIFF
--- a/src/app/search/fetchAllData.ts
+++ b/src/app/search/fetchAllData.ts
@@ -1,0 +1,16 @@
+export async function fetchAllData(page = 1, limit = 5) {
+  const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
+  const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
+  const url = `${API_SERVER}/products/?page=${page}&limit=${limit}`;
+  const res = await fetch(url, {
+    headers: {
+      "Content-Type": "application/json",
+      "client-id": `${CLIENT_ID}`,
+    },
+  });
+  const resJson = await res.json();
+  if (!resJson.ok) {
+    throw new Error("error");
+  }
+  return resJson;
+}

--- a/src/app/search/fetchSearch.ts
+++ b/src/app/search/fetchSearch.ts
@@ -12,5 +12,5 @@ export async function fetchSearch(searchText: string) {
   if (!resJson.ok) {
     throw new Error("error");
   }
-  return resJson.item;
+  return resJson;
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -29,7 +29,7 @@ export default function Page() {
   const [searchText, setSearchText] = useState("");
   const [fetchedResult, setFetchedResult] = useState<any>(null);
   const [currentPage, setCurrentPage] = useState(1);
-  const debounceValue = useDebounce(searchText, 2000);
+  const debounceValue = useDebounce(searchText, 1000);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -37,10 +37,8 @@ export default function Page() {
         let result;
         if (searchText === "") {
           result = await fetchAllData(currentPage);
-          console.log(result);
         } else {
           result = await fetchSearch(debounceValue);
-          console.log(result);
         }
         setFetchedResult(result);
       } catch (error) {
@@ -49,7 +47,7 @@ export default function Page() {
     };
 
     fetchData();
-  }, [debounceValue, searchText, currentPage]);
+  }, [debounceValue, currentPage]);
 
   const handlePageChange = (selectedPage: number) => {
     setCurrentPage(selectedPage);


### PR DESCRIPTION
검색페이지에서 검색을 할 수 없는 오류를 수정했습니다.

list 조건부 렌더링이 검색하기 전에 모든 상품을 보여줄 때의 함수 fetchAlldata 반환값과 
검색을 시작하여 특정 상품을 보여주는 함수 fetchSearch의 반환값이 달라서 생긴 오류였습니다.

두 함수의 반환값을 똑같이 일치시켜서 수정했습니다.